### PR TITLE
Allow tabs to wrap in CSS

### DIFF
--- a/ha_autogen/frontend/index.html
+++ b/ha_autogen/frontend/index.html
@@ -45,7 +45,7 @@
         .subtitle { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1rem; }
 
         /* Tabs */
-        .tabs { display: flex; gap: 0; border-bottom: 2px solid var(--border); margin-bottom: 1.5rem; overflow-x: auto; }
+        .tabs { display: flex; gap: 0; border-bottom: 2px solid var(--border); margin-bottom: 1.5rem; flex-wrap: wrap; }
         .tab-btn {
             padding: 0.6rem 1.2rem; background: none; color: var(--text-muted); border: none;
             border-bottom: 2px solid transparent; margin-bottom: -2px; cursor: pointer;


### PR DESCRIPTION
Allow tabs to wrap in CSS
Fixes underline

<img width="769" height="241" alt="image" src="https://github.com/user-attachments/assets/c4a2d66e-7edd-41d7-ab6a-6b7d40abdbf6" />
